### PR TITLE
Clearer error handling

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -16,6 +16,9 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.head_ref }}
+                  fetch-depth: 0
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -32,6 +35,6 @@ jobs:
               run: npm run lint -- --fix
 
             - name: Commit linted files
-              uses: stefanzweifel/git-auto-commit-action@v5
+              uses: stefanzweifel/git-auto-commit-action@v7
               with:
                   commit_message: "Fix code styling"

--- a/README.md
+++ b/README.md
@@ -276,11 +276,13 @@ import { usePasskeyRegister } from "@laravel/passkeys/react";
 const { register, error, errorInstance } = usePasskeyRegister();
 
 // ...
-{errorInstance instanceof PasskeyExistsError ? (
-    <p>You already registered a passkey on this device.</p>
-) : error ? (
-    <p className="error">{error}</p>
-) : null}
+{
+    errorInstance instanceof PasskeyExistsError ? (
+        <p>You already registered a passkey on this device.</p>
+    ) : error ? (
+        <p className="error">{error}</p>
+    ) : null;
+}
 ```
 
 ## Type Compatibility

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ const { register, error, errorInstance } = usePasskeyRegister();
         <p>You already registered a passkey on this device.</p>
     ) : error ? (
         <p className="error">{error}</p>
-    ) : null;
+    ) : null
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ const { register, error, errorInstance } = usePasskeyRegister();
         <p>You already registered a passkey on this device.</p>
     ) : error ? (
         <p className="error">{error}</p>
-    ) : null
+    ) : null;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,33 @@ usePasskeyRegister({
 });
 ```
 
+## Typed Errors
+
+All ceremony failures are converted to `PasskeyError` subclasses so you can branch on error type:
+
+| Class                | Thrown when                                                  |
+| -------------------- | ------------------------------------------------------------ |
+| `NotSupportedError`  | The browser does not support WebAuthn                        |
+| `UserCancelledError` | The user dismissed the native prompt                         |
+| `PasskeyExistsError` | A passkey for this account/device is already registered      |
+| `PasskeyError`       | Base class; used for server errors and any unmapped failures |
+
+`Passkeys.register()` and `Passkeys.verify()` throw these directly. The framework adapters expose them two ways: the `onError` callback receives the typed instance, and each hook returns an `errorInstance` field (alongside the string `error`) so you can branch from markup:
+
+```jsx
+import { PasskeyExistsError } from "@laravel/passkeys";
+import { usePasskeyRegister } from "@laravel/passkeys/react";
+
+const { register, error, errorInstance } = usePasskeyRegister();
+
+// ...
+{errorInstance instanceof PasskeyExistsError ? (
+    <p>You already registered a passkey on this device.</p>
+) : error ? (
+    <p className="error">{error}</p>
+) : null}
+```
+
 ## Type Compatibility
 
 This package uses TypeScript types from [`@simplewebauthn/browser`](https://www.npmjs.com/package/@simplewebauthn/browser). These types are fully compatible with the JSON output from the [`web-auth/webauthn-lib`](https://packagist.org/packages/web-auth/webauthn-lib) PHP package.

--- a/src/adapters/react.ts
+++ b/src/adapters/react.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { toError } from "../errors";
+import { PasskeyError, toPasskeyError } from "../errors";
 import { Passkeys } from "../passkeys";
 import type {
     RegisterRouteOptions,
@@ -10,12 +10,12 @@ import type {
 type UsePasskeyVerifyOptions = VerifyRouteOptions & {
     autofill?: boolean;
     onSuccess?: (response: VerifyResponse) => void;
-    onError?: (error: Error) => void;
+    onError?: (error: PasskeyError) => void;
 };
 
 type UsePasskeyRegisterOptions = RegisterRouteOptions & {
     onSuccess?: () => void;
-    onError?: (error: Error) => void;
+    onError?: (error: PasskeyError) => void;
 };
 
 export const usePasskeyVerify = ({
@@ -26,6 +26,9 @@ export const usePasskeyVerify = ({
 }: UsePasskeyVerifyOptions = {}) => {
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [errorInstance, setErrorInstance] = useState<PasskeyError | null>(
+        null,
+    );
 
     const onSuccessRef = useRef(onSuccess);
     const onErrorRef = useRef(onError);
@@ -35,9 +38,21 @@ export const usePasskeyVerify = ({
     onErrorRef.current = onError;
     routesRef.current = routes;
 
+    const resetError = () => {
+        setError(null);
+        setErrorInstance(null);
+    };
+
+    const handleError = (e: unknown) => {
+        const err = toPasskeyError(e);
+        setError(err.message);
+        setErrorInstance(err);
+        onErrorRef.current?.(err);
+    };
+
     const verify = useCallback(async (): Promise<void> => {
         setIsLoading(true);
-        setError(null);
+        resetError();
 
         try {
             const response = await Passkeys.verify({
@@ -45,9 +60,7 @@ export const usePasskeyVerify = ({
             });
             onSuccessRef.current?.(response);
         } catch (e) {
-            const err = toError(e, "Authentication failed");
-            setError(err.message);
-            onErrorRef.current?.(err);
+            handleError(e);
         } finally {
             setIsLoading(false);
         }
@@ -68,7 +81,7 @@ export const usePasskeyVerify = ({
             }
 
             setIsLoading(true);
-            setError(null);
+            resetError();
 
             try {
                 const response = await Passkeys.autofill({
@@ -79,9 +92,7 @@ export const usePasskeyVerify = ({
                     onSuccessRef.current?.(response);
                 }
             } catch (e) {
-                const err = toError(e, "Authentication failed");
-                setError(err.message);
-                onErrorRef.current?.(err);
+                handleError(e);
             } finally {
                 setIsLoading(false);
             }
@@ -100,6 +111,7 @@ export const usePasskeyVerify = ({
         verify,
         isLoading,
         error,
+        errorInstance,
         isSupported,
     };
 };
@@ -111,6 +123,9 @@ export const usePasskeyRegister = ({
 }: UsePasskeyRegisterOptions = {}) => {
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [errorInstance, setErrorInstance] = useState<PasskeyError | null>(
+        null,
+    );
 
     const onSuccessRef = useRef(onSuccess);
     const onErrorRef = useRef(onError);
@@ -123,6 +138,7 @@ export const usePasskeyRegister = ({
     const register = useCallback(async (name: string): Promise<void> => {
         setIsLoading(true);
         setError(null);
+        setErrorInstance(null);
 
         try {
             await Passkeys.register({
@@ -131,8 +147,9 @@ export const usePasskeyRegister = ({
             });
             onSuccessRef.current?.();
         } catch (e) {
-            const err = toError(e, "Registration failed");
+            const err = toPasskeyError(e);
             setError(err.message);
+            setErrorInstance(err);
             onErrorRef.current?.(err);
         } finally {
             setIsLoading(false);
@@ -145,6 +162,7 @@ export const usePasskeyRegister = ({
         register,
         isLoading,
         error,
+        errorInstance,
         isSupported,
     };
 };

--- a/src/adapters/svelte.svelte.ts
+++ b/src/adapters/svelte.svelte.ts
@@ -1,5 +1,5 @@
 import { onMount } from "svelte";
-import { toError } from "../errors";
+import { PasskeyError, toPasskeyError } from "../errors";
 import { Passkeys } from "../passkeys";
 import type {
     RegisterRouteOptions,
@@ -10,12 +10,12 @@ import type {
 type UsePasskeyVerifyOptions = VerifyRouteOptions & {
     autofill?: boolean;
     onSuccess?: (response: VerifyResponse) => void;
-    onError?: (error: Error) => void;
+    onError?: (error: PasskeyError) => void;
 };
 
 type UsePasskeyRegisterOptions = RegisterRouteOptions & {
     onSuccess?: () => void;
-    onError?: (error: Error) => void;
+    onError?: (error: PasskeyError) => void;
 };
 
 export function usePasskeyVerify({
@@ -26,19 +26,30 @@ export function usePasskeyVerify({
 }: UsePasskeyVerifyOptions = {}) {
     let isLoading = $state(false);
     let error = $state<string | null>(null);
+    let errorInstance = $state<PasskeyError | null>(null);
+
+    const resetError = () => {
+        error = null;
+        errorInstance = null;
+    };
+
+    const handleError = (e: unknown) => {
+        const err = toPasskeyError(e);
+
+        error = err.message;
+        errorInstance = err;
+        onError?.(err);
+    };
 
     const verify = async () => {
         isLoading = true;
-        error = null;
+        resetError();
 
         try {
             const response = await Passkeys.verify({ routes });
             onSuccess?.(response);
         } catch (e) {
-            const err = toError(e, "Authentication failed");
-
-            error = err.message;
-            onError?.(err);
+            handleError(e);
         } finally {
             isLoading = false;
         }
@@ -59,7 +70,7 @@ export function usePasskeyVerify({
             }
 
             isLoading = true;
-            error = null;
+            resetError();
 
             try {
                 const response = await Passkeys.autofill({
@@ -70,10 +81,7 @@ export function usePasskeyVerify({
                     onSuccess?.(response);
                 }
             } catch (e) {
-                const err = toError(e, "Authentication failed");
-
-                error = err.message;
-                onError?.(err);
+                handleError(e);
             } finally {
                 isLoading = false;
             }
@@ -92,6 +100,9 @@ export function usePasskeyVerify({
         get error() {
             return error;
         },
+        get errorInstance() {
+            return errorInstance;
+        },
         get isSupported() {
             return Passkeys.isSupported();
         },
@@ -105,10 +116,12 @@ export function usePasskeyRegister({
 }: UsePasskeyRegisterOptions = {}) {
     let isLoading = $state(false);
     let error = $state<string | null>(null);
+    let errorInstance = $state<PasskeyError | null>(null);
 
     const register = async (name: string) => {
         isLoading = true;
         error = null;
+        errorInstance = null;
 
         try {
             await Passkeys.register({
@@ -117,9 +130,10 @@ export function usePasskeyRegister({
             });
             onSuccess?.();
         } catch (e) {
-            const err = toError(e, "Registration failed");
+            const err = toPasskeyError(e);
 
             error = err.message;
+            errorInstance = err;
             onError?.(err);
         } finally {
             isLoading = false;
@@ -133,6 +147,9 @@ export function usePasskeyRegister({
         },
         get error() {
             return error;
+        },
+        get errorInstance() {
+            return errorInstance;
         },
         get isSupported() {
             return Passkeys.isSupported();

--- a/src/adapters/vue.ts
+++ b/src/adapters/vue.ts
@@ -1,5 +1,5 @@
 import { onMounted, onUnmounted, ref } from "vue";
-import { toError } from "../errors";
+import { PasskeyError, toPasskeyError } from "../errors";
 import { Passkeys } from "../passkeys";
 import type {
     RegisterRouteOptions,
@@ -10,12 +10,12 @@ import type {
 type UsePasskeyVerifyOptions = VerifyRouteOptions & {
     autofill?: boolean;
     onSuccess?: (response: VerifyResponse) => void;
-    onError?: (error: Error) => void;
+    onError?: (error: PasskeyError) => void;
 };
 
 type UsePasskeyRegisterOptions = RegisterRouteOptions & {
     onSuccess?: () => void;
-    onError?: (error: Error) => void;
+    onError?: (error: PasskeyError) => void;
 };
 
 export const usePasskeyVerify = ({
@@ -26,19 +26,30 @@ export const usePasskeyVerify = ({
 }: UsePasskeyVerifyOptions = {}) => {
     const isLoading = ref(false);
     const error = ref<string | null>(null);
+    const errorInstance = ref<PasskeyError | null>(null);
+
+    const resetError = () => {
+        error.value = null;
+        errorInstance.value = null;
+    };
+
+    const handleError = (e: unknown) => {
+        const err = toPasskeyError(e);
+
+        error.value = err.message;
+        errorInstance.value = err;
+        onError?.(err);
+    };
 
     const verify = async () => {
         isLoading.value = true;
-        error.value = null;
+        resetError();
 
         try {
             const response = await Passkeys.verify({ routes });
             onSuccess?.(response);
         } catch (e) {
-            const err = toError(e, "Authentication failed");
-
-            error.value = err.message;
-            onError?.(err);
+            handleError(e);
         } finally {
             isLoading.value = false;
         }
@@ -60,7 +71,7 @@ export const usePasskeyVerify = ({
         }
 
         isLoading.value = true;
-        error.value = null;
+        resetError();
 
         try {
             const response = await Passkeys.autofill({
@@ -71,10 +82,7 @@ export const usePasskeyVerify = ({
                 onSuccess?.(response);
             }
         } catch (e) {
-            const err = toError(e, "Authentication failed");
-
-            error.value = err.message;
-            onError?.(err);
+            handleError(e);
         } finally {
             isLoading.value = false;
         }
@@ -88,6 +96,7 @@ export const usePasskeyVerify = ({
         verify,
         isLoading,
         error,
+        errorInstance,
         isSupported: Passkeys.isSupported(),
     };
 };
@@ -99,10 +108,12 @@ export const usePasskeyRegister = ({
 }: UsePasskeyRegisterOptions = {}) => {
     const isLoading = ref(false);
     const error = ref<string | null>(null);
+    const errorInstance = ref<PasskeyError | null>(null);
 
     const register = async (name: string) => {
         isLoading.value = true;
         error.value = null;
+        errorInstance.value = null;
 
         try {
             await Passkeys.register({
@@ -111,9 +122,10 @@ export const usePasskeyRegister = ({
             });
             onSuccess?.();
         } catch (e) {
-            const err = toError(e, "Registration failed");
+            const err = toPasskeyError(e);
 
             error.value = err.message;
+            errorInstance.value = err;
             onError?.(err);
         } finally {
             isLoading.value = false;
@@ -124,6 +136,7 @@ export const usePasskeyRegister = ({
         register,
         isLoading,
         error,
+        errorInstance,
         isSupported: Passkeys.isSupported(),
     };
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -39,16 +39,6 @@ export class PasskeyExistsError extends PasskeyError {
 }
 
 /**
- * Thrown when no passkey is found (during authentication).
- */
-export class NoPasskeyFoundError extends PasskeyError {
-    constructor() {
-        super("No passkey found for this account.");
-        this.name = "NoPasskeyFoundError";
-    }
-}
-
-/**
  * Convert WebAuthn errors to friendly passkey errors.
  */
 export const toPasskeyError = (error: unknown): PasskeyError => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -61,7 +61,3 @@ export const toPasskeyError = (error: unknown): PasskeyError => {
             return new PasskeyError(error.message);
     }
 };
-
-export const toError = (e: unknown, fallbackMessage: string): Error => {
-    return e instanceof Error ? e : new Error(String(e) || fallbackMessage);
-};

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ export {
     NotSupportedError,
     UserCancelledError,
     PasskeyExistsError,
-    NoPasskeyFoundError,
 } from "./errors";
 
 export { defaultRoutes } from "./routes";

--- a/tests/adapters/TestVerify.svelte
+++ b/tests/adapters/TestVerify.svelte
@@ -15,6 +15,7 @@
 <div>
     <span data-testid="loading">{passkey.isLoading}</span>
     <span data-testid="error">{passkey.error ?? ""}</span>
+    <span data-testid="error-instance-name">{passkey.errorInstance?.name ?? ""}</span>
     <span data-testid="supported">{passkey.isSupported}</span>
     <button data-testid="verify" onclick={() => passkey.verify()}>Verify</button>
 </div>

--- a/tests/adapters/react.test.tsx
+++ b/tests/adapters/react.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { Passkeys } from "../../src/passkeys";
+import { PasskeyError, PasskeyExistsError } from "../../src/errors";
 import { usePasskeyVerify, usePasskeyRegister } from "../../src/adapters/react";
 
 vi.mock("../../src/passkeys", () => ({
@@ -83,8 +84,29 @@ describe("React adapter", () => {
             });
 
             expect(result.current.error).toBe("Verify failed");
+            expect(result.current.errorInstance).toBeInstanceOf(PasskeyError);
             expect(onError).toHaveBeenCalledWith(
                 expect.objectContaining({ message: "Verify failed" }),
+            );
+        });
+
+        it("exposes typed error instance for instanceof branching", async () => {
+            (Passkeys.verify as Mock).mockRejectedValue(
+                new PasskeyExistsError(),
+            );
+
+            const { result } = renderHook(() => usePasskeyVerify({ routes }));
+
+            await act(async () => {
+                result.current.verify();
+            });
+
+            await waitFor(() => {
+                expect(result.current.isLoading).toBe(false);
+            });
+
+            expect(result.current.errorInstance).toBeInstanceOf(
+                PasskeyExistsError,
             );
         });
 

--- a/tests/adapters/svelte.test.ts
+++ b/tests/adapters/svelte.test.ts
@@ -9,6 +9,7 @@ import {
 } from "vitest";
 import { render, fireEvent, waitFor, cleanup } from "@testing-library/svelte";
 import { Passkeys } from "../../src/passkeys";
+import { PasskeyExistsError } from "../../src/errors";
 import TestVerify from "./TestVerify.svelte";
 import TestRegister from "./TestRegister.svelte";
 
@@ -84,9 +85,29 @@ describe("Svelte adapter", () => {
                 expect(getByTestId("error").textContent).toBe("Verify failed");
             });
 
+            expect(getByTestId("error-instance-name").textContent).toBe(
+                "PasskeyError",
+            );
             expect(onError).toHaveBeenCalledWith(
                 expect.objectContaining({ message: "Verify failed" }),
             );
+        });
+
+        it("exposes typed error instance for instanceof branching", async () => {
+            (Passkeys.verify as Mock).mockRejectedValue(
+                new PasskeyExistsError(),
+            );
+
+            const { getByTestId, getByRole } = render(TestVerify, {
+                props: { routes },
+            });
+
+            await fireEvent.click(getByRole("button", { name: "Verify" }));
+            await waitFor(() => {
+                expect(getByTestId("error-instance-name").textContent).toBe(
+                    "PasskeyExistsError",
+                );
+            });
         });
 
         it("does not call autofill by default", async () => {

--- a/tests/adapters/vue.test.ts
+++ b/tests/adapters/vue.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { defineComponent, h } from "vue";
 import { Passkeys } from "../../src/passkeys";
+import { PasskeyError, PasskeyExistsError } from "../../src/errors";
 import { usePasskeyVerify, usePasskeyRegister } from "../../src/adapters/vue";
 
 vi.mock("../../src/passkeys", () => ({
@@ -129,9 +130,30 @@ describe("Vue adapter", () => {
             expect(wrapper.find("[data-error]").text()).toBe("Verify failed");
             const vm = wrapper.vm as unknown as {
                 onError: ReturnType<typeof vi.fn>;
+                passkey: { errorInstance: { value: unknown } };
             };
+            expect(vm.passkey.errorInstance.value).toBeInstanceOf(PasskeyError);
             expect(vm.onError).toHaveBeenCalledWith(
                 expect.objectContaining({ message: "Verify failed" }),
+            );
+        });
+
+        it("exposes typed error instance for instanceof branching", async () => {
+            (Passkeys.verify as Mock).mockRejectedValue(
+                new PasskeyExistsError(),
+            );
+
+            const wrapper = mount(createVerifyWrapper());
+            await flushPromises();
+
+            await wrapper.find("[data-verify]").trigger("click");
+            await flushPromises();
+
+            const vm = wrapper.vm as unknown as {
+                passkey: { errorInstance: { value: unknown } };
+            };
+            expect(vm.passkey.errorInstance.value).toBeInstanceOf(
+                PasskeyExistsError,
             );
         });
 


### PR DESCRIPTION
- **Dropped `NoPasskeyFoundError`** — the class was exported from the public API but nothing ever constructed it. No WebAuthn DOM error maps to it, and server-side "not found" responses are already surfaced through the base `PasskeyError`.
- **Propagated typed errors through framework adapters.** The core already throws `PasskeyError` subclasses (via `toPasskeyError`), but the React/Vue/Svelte hooks wrapped them with a generic `Error` helper, so consumers had no way to branch on `PasskeyExistsError` etc. from a hook. `onError` is now typed as `(error: PasskeyError) => void`, and the adapters use `toPasskeyError` directly instead of the (now removed) `toError` helper.
- **Added `errorInstance` to each hook's return.** Keeps `error: string | null` for the common "just render the message" case, but also exposes the typed instance so consumers can do `{errorInstance instanceof PasskeyExistsError && ...}` straight from markup without wiring an `onError` callback purely to stash the typed error in local state.
- **README** gets a new "Typed Errors" section listing the classes and showing the `errorInstance` branching pattern.