### PR TITLE
SSR Optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,11 +288,13 @@ import { usePasskeyRegister } from "@laravel/passkeys/react";
 const { register, error, errorInstance } = usePasskeyRegister();
 
 // ...
-{errorInstance instanceof PasskeyExistsError ? (
-    <p>You already registered a passkey on this device.</p>
-) : error ? (
-    <p className="error">{error}</p>
-) : null}
+{
+    errorInstance instanceof PasskeyExistsError ? (
+        <p>You already registered a passkey on this device.</p>
+    ) : error ? (
+        <p className="error">{error}</p>
+    ) : null;
+}
 ```
 
 ## Type Compatibility

--- a/README.md
+++ b/README.md
@@ -127,40 +127,46 @@ const {
 
 ### Svelte
 
+Access the returned values through the hook object (don't destructure), so Svelte's reactivity stays live:
+
 ```svelte
 <script>
     import { usePasskeyVerify, usePasskeyRegister } from "@laravel/passkeys/svelte";
 
-    const { verify, isLoading: verifyLoading, error: verifyError, isSupported } =
-        usePasskeyVerify({
-            autofill: true,
-            onSuccess: (response) => {
-                if (response.redirect) window.location.href = response.redirect;
-            },
-        });
+    const verify = usePasskeyVerify({
+        autofill: true,
+        onSuccess: (response) => {
+            if (response.redirect) window.location.href = response.redirect;
+        },
+    });
 
+    const register = usePasskeyRegister();
     let name = $state("");
-    const { register, isLoading: registerLoading, error: registerError } =
-        usePasskeyRegister();
 </script>
 
 <!-- Include webauthn and set autofill: true to show passkeys in the input -->
 <input type="email" autocomplete="email webauthn" />
 
-<button onclick={verify} disabled={!isSupported || verifyLoading}>
-    {verifyLoading ? "Authenticating..." : "Sign in with passkey"}
+<button onclick={verify.verify} disabled={!verify.isSupported || verify.isLoading}>
+    {verify.isLoading ? "Authenticating..." : "Sign in with passkey"}
 </button>
-{#if verifyError}<p class="error">{verifyError}</p>{/if}
+{#if verify.error}<p class="error">{verify.error}</p>{/if}
 
 <input bind:value={name} placeholder="Passkey name" />
 <button
-    onclick={() => register(name)}
-    disabled={registerLoading || !name}
+    onclick={() => register.register(name)}
+    disabled={register.isLoading || !name}
 >
-    {registerLoading ? "Registering..." : "Add passkey"}
+    {register.isLoading ? "Registering..." : "Add passkey"}
 </button>
-{#if registerError}<p class="error">{registerError}</p>{/if}
+{#if register.error}<p class="error">{register.error}</p>{/if}
 ```
+
+## Server-Side Rendering
+
+WebAuthn is a browser-only API. The framework hooks are SSR-safe: on the server and during hydration, `isSupported` renders as `false`, then updates to the real value after the component mounts. This avoids hydration warnings without any user-visible flash — in Vue and Svelte the post-mount update runs as a microtask before the browser paints; in React it's handled by `useSyncExternalStore` (client-only apps see the real value on the first render).
+
+If you need the synchronous value outside a component lifecycle, call `Passkeys.isSupported()` directly — it returns `false` under Node without throwing.
 
 ## Core API
 

--- a/src/adapters/react.ts
+++ b/src/adapters/react.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+    useSyncExternalStore,
+} from "react";
 import { toError } from "../errors";
 import { Passkeys } from "../passkeys";
 import type {
@@ -18,6 +24,14 @@ type UsePasskeyRegisterOptions = RegisterRouteOptions & {
     onError?: (error: Error) => void;
 };
 
+// Stable references for useSyncExternalStore. `subscribe` is a no-op because
+// WebAuthn support doesn't change during a session; we only care about the
+// SSR/client split that `getServerSnapshot` provides.
+const noop = (): void => undefined;
+const subscribeSupport = () => noop;
+const getSupportClientSnapshot = () => Passkeys.isSupported();
+const getSupportServerSnapshot = () => false;
+
 export const usePasskeyVerify = ({
     autofill = false,
     routes,
@@ -26,6 +40,11 @@ export const usePasskeyVerify = ({
 }: UsePasskeyVerifyOptions = {}) => {
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const isSupported = useSyncExternalStore(
+        subscribeSupport,
+        getSupportClientSnapshot,
+        getSupportServerSnapshot,
+    );
 
     const onSuccessRef = useRef(onSuccess);
     const onErrorRef = useRef(onError);
@@ -94,8 +113,6 @@ export const usePasskeyVerify = ({
         };
     }, [autofill]);
 
-    const isSupported = useMemo(() => Passkeys.isSupported(), []);
-
     return {
         verify,
         isLoading,
@@ -111,6 +128,11 @@ export const usePasskeyRegister = ({
 }: UsePasskeyRegisterOptions = {}) => {
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const isSupported = useSyncExternalStore(
+        subscribeSupport,
+        getSupportClientSnapshot,
+        getSupportServerSnapshot,
+    );
 
     const onSuccessRef = useRef(onSuccess);
     const onErrorRef = useRef(onError);
@@ -138,8 +160,6 @@ export const usePasskeyRegister = ({
             setIsLoading(false);
         }
     }, []);
-
-    const isSupported = useMemo(() => Passkeys.isSupported(), []);
 
     return {
         register,

--- a/src/adapters/svelte.svelte.ts
+++ b/src/adapters/svelte.svelte.ts
@@ -26,6 +26,7 @@ export function usePasskeyVerify({
 }: UsePasskeyVerifyOptions = {}) {
     let isLoading = $state(false);
     let error = $state<string | null>(null);
+    let isSupported = $state(false);
 
     const verify = async () => {
         isLoading = true;
@@ -45,6 +46,8 @@ export function usePasskeyVerify({
     };
 
     onMount(() => {
+        isSupported = Passkeys.isSupported();
+
         if (!autofill) {
             return;
         }
@@ -93,7 +96,7 @@ export function usePasskeyVerify({
             return error;
         },
         get isSupported() {
-            return Passkeys.isSupported();
+            return isSupported;
         },
     };
 }
@@ -105,6 +108,11 @@ export function usePasskeyRegister({
 }: UsePasskeyRegisterOptions = {}) {
     let isLoading = $state(false);
     let error = $state<string | null>(null);
+    let isSupported = $state(false);
+
+    onMount(() => {
+        isSupported = Passkeys.isSupported();
+    });
 
     const register = async (name: string) => {
         isLoading = true;
@@ -135,7 +143,7 @@ export function usePasskeyRegister({
             return error;
         },
         get isSupported() {
-            return Passkeys.isSupported();
+            return isSupported;
         },
     };
 }

--- a/src/adapters/vue.ts
+++ b/src/adapters/vue.ts
@@ -26,6 +26,7 @@ export const usePasskeyVerify = ({
 }: UsePasskeyVerifyOptions = {}) => {
     const isLoading = ref(false);
     const error = ref<string | null>(null);
+    const isSupported = ref(false);
 
     const verify = async () => {
         isLoading.value = true;
@@ -45,6 +46,8 @@ export const usePasskeyVerify = ({
     };
 
     onMounted(async () => {
+        isSupported.value = Passkeys.isSupported();
+
         if (!autofill) {
             return;
         }
@@ -88,7 +91,7 @@ export const usePasskeyVerify = ({
         verify,
         isLoading,
         error,
-        isSupported: Passkeys.isSupported(),
+        isSupported,
     };
 };
 
@@ -99,6 +102,11 @@ export const usePasskeyRegister = ({
 }: UsePasskeyRegisterOptions = {}) => {
     const isLoading = ref(false);
     const error = ref<string | null>(null);
+    const isSupported = ref(false);
+
+    onMounted(() => {
+        isSupported.value = Passkeys.isSupported();
+    });
 
     const register = async (name: string) => {
         isLoading.value = true;
@@ -124,6 +132,6 @@ export const usePasskeyRegister = ({
         register,
         isLoading,
         error,
-        isSupported: Passkeys.isSupported(),
+        isSupported,
     };
 };

--- a/tests/adapters/react.test.tsx
+++ b/tests/adapters/react.test.tsx
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error -- no @types/react-dom installed; only used for SSR test
+import { renderToString } from "react-dom/server";
 import { Passkeys } from "../../src/passkeys";
 import { usePasskeyVerify, usePasskeyRegister } from "../../src/adapters/react";
 
@@ -41,6 +44,21 @@ describe("React adapter", () => {
             const { result } = renderHook(() => usePasskeyVerify({ routes }));
 
             expect(result.current.isSupported).toBe(false);
+        });
+
+        it("renders isSupported as false during SSR", () => {
+            (Passkeys.isSupported as Mock).mockReturnValue(true);
+
+            function Probe() {
+                const { isSupported } = usePasskeyVerify({ routes });
+
+                return <span>{String(isSupported)}</span>;
+            }
+
+            const html = renderToString(<Probe />);
+
+            expect(html).toContain("false");
+            expect(Passkeys.isSupported).not.toHaveBeenCalled();
         });
 
         it("calls Passkeys.verify with routes and updates state on success", async () => {

--- a/tests/adapters/vue.test.ts
+++ b/tests/adapters/vue.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
-import { defineComponent, h } from "vue";
+import { defineComponent, h, createSSRApp } from "vue";
+import { renderToString } from "@vue/server-renderer";
 import { Passkeys } from "../../src/passkeys";
 import { usePasskeyVerify, usePasskeyRegister } from "../../src/adapters/vue";
 
@@ -42,7 +43,7 @@ const createVerifyWrapper = (autofill = false) =>
                 h(
                     "span",
                     { "data-supported": "" },
-                    String(passkey.isSupported),
+                    String(passkey.isSupported.value),
                 ),
                 h(
                     "button",
@@ -65,7 +66,11 @@ const RegisterWrapper = defineComponent({
         return h("div", [
             h("span", { "data-loading": "" }, String(passkey.isLoading.value)),
             h("span", { "data-error": "" }, passkey.error.value ?? ""),
-            h("span", { "data-supported": "" }, String(passkey.isSupported)),
+            h(
+                "span",
+                { "data-supported": "" },
+                String(passkey.isSupported.value),
+            ),
             h(
                 "button",
                 {
@@ -95,6 +100,26 @@ describe("Vue adapter", () => {
             expect(wrapper.find("[data-loading]").text()).toBe("false");
             expect(wrapper.find("[data-error]").text()).toBe("");
             expect(wrapper.find("[data-supported]").text()).toBe("true");
+        });
+
+        it("renders isSupported as false during SSR", async () => {
+            (Passkeys.isSupported as Mock).mockReturnValue(true);
+
+            const Probe = defineComponent({
+                setup() {
+                    const { isSupported } = usePasskeyVerify({ routes });
+
+                    return { isSupported };
+                },
+                render() {
+                    return h("span", String(this.isSupported));
+                },
+            });
+
+            const html = await renderToString(createSSRApp(Probe));
+
+            expect(html).toContain("false");
+            expect(Passkeys.isSupported).not.toHaveBeenCalled();
         });
 
         it("calls Passkeys.verify with routes and calls onSuccess on success", async () => {


### PR DESCRIPTION
Makes the framework hooks safe to use under SSR. Before this, `isSupported` was evaluated synchronously when the hook ran — which returned `false` on the server (no `window.PublicKeyCredential`) and `true` on the client, producing a hydration mismatch warning for any consumer doing Inertia SSR.

React now uses `useSyncExternalStore` with `() => false` as the server snapshot, so client-only apps get the real value on the very first render (no disabled-button flash) and SSR apps get a single post-hydration update without a warning. That one's a clean win with no tradeoff.

Vue and Svelte don't have an equivalent primitive — hydration is DOM-diff-based, so the only way to avoid the warning is for the client's first render to match whatever the server produced. I went with the deferred pattern: `isSupported` starts as `false`, and `onMounted` / `onMount` flips it to the real value after hydration completes. In practice the "one frame disabled" is imperceptible because the mount callback, reactive update, and DOM patch all run as microtasks before the browser paints.

That's the only user-facing change in Vue: `isSupported` went from a plain boolean returned from `setup()` to a `ref`, so anyone reading it in `<script setup>` now needs `.value`. Templates auto-unwrap so template usage is unchanged. Svelte kept its getter shape so there's no API break there.

While updating the Svelte example in the README I also fixed a latent reactivity bug — it was destructuring `isLoading`/`error`/`isSupported` off the returned object, which in Svelte 5 captures a one-time scalar rather than a live binding. The example now accesses everything through the hook object so reactivity actually works.

Added `renderToString` tests for React and Vue to pin the SSR behavior. Svelte SSR coverage is skipped because this package's vite test config pins `["browser", "import"]` conditions, so `svelte/server` can't find its server-entry `onMount` no-op inside vitest — a real SvelteKit/Vite SSR pipeline resolves it correctly.
