### PR TITLE
Safer cookie split

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -35,15 +35,16 @@ const getCsrfTokenFromMetaTag = (): CsrfToken | null => {
  * Get the CSRF token from the XSRF-TOKEN cookie.
  */
 const getCsrfTokenFromCookie = (): CsrfToken | null => {
+    const cookieIdentifier = "XSRF-TOKEN=";
     const cookie = document.cookie
         .split("; ")
-        .find((row) => row.startsWith("XSRF-TOKEN="));
+        .find((row) => row.startsWith(cookieIdentifier));
 
     if (!cookie) {
         return null;
     }
 
-    const value = cookie.split("=")[1];
+    const value = cookie.slice(cookieIdentifier.length);
 
     return value
         ? { header: "X-XSRF-TOKEN", value: decodeURIComponent(value) }

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -144,6 +144,31 @@ describe("http", () => {
             });
         });
 
+        it("preserves raw = characters inside the XSRF cookie value", async () => {
+            Object.defineProperty(document, "cookie", {
+                writable: true,
+                value: "XSRF-TOKEN=abc=def",
+            });
+
+            fetchMock.mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve({}),
+            });
+
+            await post("/api/test", {});
+
+            expect(fetchMock).toHaveBeenCalledWith("/api/test", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Accept: "application/json",
+                    "X-XSRF-TOKEN": "abc=def",
+                },
+                credentials: "same-origin",
+                body: JSON.stringify({}),
+            });
+        });
+
         it("decodes URL-encoded XSRF cookie", async () => {
             Object.defineProperty(document, "cookie", {
                 writable: true,


### PR DESCRIPTION
The XSRF cookie parser was splitting on `=` and taking the second segment, which silently truncates the token if the value itself contains a raw `=`. In practice Laravel always URL-encodes the token so we never hit this, but a misbehaving proxy or future framework change emitting the raw form would produce a truncated token on the wire and a 419 nobody can explain.

Swapped the split for a slice that takes everything after the `XSRF-TOKEN=` prefix, so the full value survives intact. Added a regression test with a literal `=` inside the cookie value to lock the behavior in.