### PR TITLE
Add `prepublishOnly` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     ],
     "scripts": {
         "prepare": "npm run build",
+        "prepublishOnly": "npm run lint && npm run typecheck && npm test -- --run",
         "build": "vite build",
         "dev": "vite build --watch",
         "test": "vitest",


### PR DESCRIPTION
Adds a `prepublishOnly` script that runs lint, typecheck, and tests before `npm publish`. It's a safety net for the case where someone cuts a release locally without CI having validated the branch — catches a broken build before it hits the registry rather than after.
