### PR TITLE
React autofill race condition

### DIFF
--- a/src/adapters/react.ts
+++ b/src/adapters/react.ts
@@ -58,12 +58,14 @@ export const usePasskeyVerify = ({
             return;
         }
 
+        let cancelled = false;
+
         Passkeys.cancel();
 
         const attemptToAutofill = async (): Promise<void> => {
             const supported = await Passkeys.isAutofillSupported();
 
-            if (!supported) {
+            if (cancelled || !supported) {
                 return;
             }
 
@@ -75,11 +77,18 @@ export const usePasskeyVerify = ({
                     routes: routesRef.current,
                 });
 
-                if (response) {
-                    onSuccessRef.current?.(response);
+                if (cancelled || !response) {
+                    return;
                 }
+
+                onSuccessRef.current?.(response);
             } catch (e) {
+                if (cancelled) {
+                    return;
+                }
+
                 const err = toError(e, "Authentication failed");
+
                 setError(err.message);
                 onErrorRef.current?.(err);
             } finally {
@@ -90,6 +99,7 @@ export const usePasskeyVerify = ({
         void attemptToAutofill();
 
         return () => {
+            cancelled = true;
             Passkeys.cancel();
         };
     }, [autofill]);

--- a/tests/adapters/react.test.tsx
+++ b/tests/adapters/react.test.tsx
@@ -117,6 +117,39 @@ describe("React adapter", () => {
             expect(Passkeys.autofill).toHaveBeenCalledWith({ routes });
         });
 
+        it("skips post-unmount callbacks when autofill resolves after unmount", async () => {
+            (Passkeys.isAutofillSupported as Mock).mockResolvedValue(true);
+
+            let resolveAutofill: (value: unknown) => void = () => {};
+            (Passkeys.autofill as Mock).mockReturnValue(
+                new Promise((resolve) => {
+                    resolveAutofill = resolve;
+                }),
+            );
+
+            const onSuccess = vi.fn();
+            const onError = vi.fn();
+            const { unmount } = renderHook(() =>
+                usePasskeyVerify({
+                    routes,
+                    onSuccess,
+                    onError,
+                    autofill: true,
+                }),
+            );
+
+            await waitFor(() => {
+                expect(Passkeys.autofill).toHaveBeenCalled();
+            });
+
+            unmount();
+            resolveAutofill({ redirect: "/home" });
+            await Promise.resolve();
+
+            expect(onSuccess).not.toHaveBeenCalled();
+            expect(onError).not.toHaveBeenCalled();
+        });
+
         it("does not call autofill when enabled but unsupported", async () => {
             (Passkeys.isAutofillSupported as Mock).mockResolvedValue(false);
 


### PR DESCRIPTION
Fixes a small race in React's autofill effect: if the component unmounted mid-ceremony, the continuation after each `await` would still set state and invoke `onSuccess`/`onError` on a dead component.

Added a `cancelled` flag that the cleanup flips, and checked it at the three places it actually matters — before kicking off the WebAuthn ceremony, before calling `onSuccess`, and before calling `onError`. The `setIsLoading(false)` in the finally block is left alone since React 18+ silently ignores setState on unmounted components.