### PR TITLE
Add InvalidDomainError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ### What's Changed
 
-* Review Edits by [@joetannenbaum](https://github.com/joetannenbaum) in https://github.com/laravel/passkeys/pull/1
-* Add `prepublishOnly` script by [@joetannenbaum](https://github.com/joetannenbaum) in https://github.com/laravel/passkeys/pull/5
-* Clearer error handling by [@joetannenbaum](https://github.com/joetannenbaum) in https://github.com/laravel/passkeys/pull/2
-* SSR Optimizations by [@joetannenbaum](https://github.com/joetannenbaum) in https://github.com/laravel/passkeys/pull/3
-* Safer cookie split by [@joetannenbaum](https://github.com/joetannenbaum) in https://github.com/laravel/passkeys/pull/4
-* React autofill race condition by [@joetannenbaum](https://github.com/joetannenbaum) in https://github.com/laravel/passkeys/pull/6
-* Release script by [@joetannenbaum](https://github.com/joetannenbaum) in https://github.com/laravel/passkeys/pull/7
+- Review Edits by [@joetannenbaum](https://github.com/joetannenbaum) in https://github.com/laravel/passkeys/pull/1
+- Add `prepublishOnly` script by [@joetannenbaum](https://github.com/joetannenbaum) in https://github.com/laravel/passkeys/pull/5
+- Clearer error handling by [@joetannenbaum](https://github.com/joetannenbaum) in https://github.com/laravel/passkeys/pull/2
+- SSR Optimizations by [@joetannenbaum](https://github.com/joetannenbaum) in https://github.com/laravel/passkeys/pull/3
+- Safer cookie split by [@joetannenbaum](https://github.com/joetannenbaum) in https://github.com/laravel/passkeys/pull/4
+- React autofill race condition by [@joetannenbaum](https://github.com/joetannenbaum) in https://github.com/laravel/passkeys/pull/6
+- Release script by [@joetannenbaum](https://github.com/joetannenbaum) in https://github.com/laravel/passkeys/pull/7
 
 ### New Contributors
 
-* [@joetannenbaum](https://github.com/joetannenbaum) made their first contribution in https://github.com/laravel/passkeys/pull/1
+- [@joetannenbaum](https://github.com/joetannenbaum) made their first contribution in https://github.com/laravel/passkeys/pull/1
 
 **Full Changelog**: https://github.com/laravel/passkeys/commits/v0.1.0

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ All ceremony failures are converted to `PasskeyError` subclasses so you can bran
 | `NotSupportedError`  | The browser does not support WebAuthn                        |
 | `UserCancelledError` | The user dismissed the native prompt                         |
 | `PasskeyExistsError` | A passkey for this account/device is already registered      |
+| `InvalidDomainError` | Passkeys are used from an invalid domain                     |
 | `PasskeyError`       | Base class; used for server errors and any unmapped failures |
 
 `Passkeys.register()` and `Passkeys.verify()` throw these directly. The framework adapters expose them two ways: the `onError` callback receives the typed instance, and each hook returns an `errorInstance` field (alongside the string `error`) so you can branch from markup:

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -42,9 +42,11 @@ export class PasskeyExistsError extends PasskeyError {
  * Thrown when passkeys are used from an invalid domain.
  */
 export class InvalidDomainError extends PasskeyError {
-    constructor() {
+    constructor(domain?: string) {
+        const subject = domain ?? "this domain";
+
         super(
-            "Passkeys don't work on this domain. If you're developing locally, use localhost instead of 127.0.0.1.",
+            `Passkeys can't be used on ${subject}. For local development, use localhost.`,
         );
         this.name = "InvalidDomainError";
     }
@@ -63,7 +65,7 @@ export const toPasskeyError = (error: unknown): PasskeyError => {
     }
 
     if (isInvalidDomainError(error)) {
-        return new InvalidDomainError();
+        return new InvalidDomainError(currentHostname());
     }
 
     switch (error.name) {
@@ -84,4 +86,10 @@ const isInvalidDomainError = (error: Error): boolean =>
 const errorCode = (error: Error): string | undefined =>
     "code" in error && typeof error.code === "string"
         ? error.code
+        : undefined;
+
+const currentHostname = (): string | undefined =>
+    typeof globalThis.location?.hostname === "string" &&
+    globalThis.location.hostname.length > 0
+        ? globalThis.location.hostname
         : undefined;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -84,9 +84,7 @@ const isInvalidDomainError = (error: Error): boolean =>
     errorCode(error) === "ERROR_INVALID_DOMAIN";
 
 const errorCode = (error: Error): string | undefined =>
-    "code" in error && typeof error.code === "string"
-        ? error.code
-        : undefined;
+    "code" in error && typeof error.code === "string" ? error.code : undefined;
 
 const currentHostname = (): string | undefined =>
     typeof globalThis.location?.hostname === "string" &&

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -39,6 +39,18 @@ export class PasskeyExistsError extends PasskeyError {
 }
 
 /**
+ * Thrown when passkeys are used from an invalid domain.
+ */
+export class InvalidDomainError extends PasskeyError {
+    constructor() {
+        super(
+            "Passkeys don't work on this domain. If you're developing locally, use localhost instead of 127.0.0.1.",
+        );
+        this.name = "InvalidDomainError";
+    }
+}
+
+/**
  * Convert WebAuthn errors to friendly passkey errors.
  */
 export const toPasskeyError = (error: unknown): PasskeyError => {
@@ -48,6 +60,10 @@ export const toPasskeyError = (error: unknown): PasskeyError => {
 
     if (!(error instanceof Error)) {
         return new PasskeyError("An unknown error occurred.");
+    }
+
+    if (isInvalidDomainError(error)) {
+        return new InvalidDomainError();
     }
 
     switch (error.name) {
@@ -61,3 +77,11 @@ export const toPasskeyError = (error: unknown): PasskeyError => {
             return new PasskeyError(error.message);
     }
 };
+
+const isInvalidDomainError = (error: Error): boolean =>
+    errorCode(error) === "ERROR_INVALID_DOMAIN";
+
+const errorCode = (error: Error): string | undefined =>
+    "code" in error && typeof error.code === "string"
+        ? error.code
+        : undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export {
     NotSupportedError,
     UserCancelledError,
     PasskeyExistsError,
+    InvalidDomainError,
 } from "./errors";
 
 export { defaultRoutes } from "./routes";

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
     PasskeyError,
     NotSupportedError,
@@ -40,12 +40,18 @@ describe("toPasskeyError", () => {
         const error = new Error();
         Object.assign(error, { code: "ERROR_INVALID_DOMAIN" });
 
-        const result = toPasskeyError(error);
+        vi.stubGlobal("location", { hostname: "127.0.0.1" });
 
-        expect(result).toBeInstanceOf(InvalidDomainError);
-        expect(result.message).toBe(
-            "Passkeys don't work on this domain. If you're developing locally, use localhost instead of 127.0.0.1.",
-        );
+        try {
+            const result = toPasskeyError(error);
+
+            expect(result).toBeInstanceOf(InvalidDomainError);
+            expect(result.message).toBe(
+                "Passkeys can't be used on 127.0.0.1. For local development, use localhost.",
+            );
+        } finally {
+            vi.unstubAllGlobals();
+        }
     });
 
     it("wraps unknown errors preserving message", () => {

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -4,6 +4,7 @@ import {
     NotSupportedError,
     UserCancelledError,
     PasskeyExistsError,
+    InvalidDomainError,
     toPasskeyError,
 } from "../src/errors";
 
@@ -33,6 +34,18 @@ describe("toPasskeyError", () => {
         error.name = "NotSupportedError";
 
         expect(toPasskeyError(error)).toBeInstanceOf(NotSupportedError);
+    });
+
+    it("converts SimpleWebAuthn invalid domain errors by code", () => {
+        const error = new Error();
+        Object.assign(error, { code: "ERROR_INVALID_DOMAIN" });
+
+        const result = toPasskeyError(error);
+
+        expect(result).toBeInstanceOf(InvalidDomainError);
+        expect(result.message).toBe(
+            "Passkeys don't work on this domain. If you're developing locally, use localhost instead of 127.0.0.1.",
+        );
     });
 
     it("wraps unknown errors preserving message", () => {


### PR DESCRIPTION
Adds a typed `InvalidDomainError` for SimpleWebAuthn’s `ERROR_INVALID_DOMAIN` failures and provides a helpful default message.