### PR TITLE
Throw a clear error when a passkey request is redirected instead of returning JSON

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -91,6 +91,8 @@ export const get = async <T>(url: string): Promise<T> => {
         await handleErrorResponse(response);
     }
 
+    assertNotRedirected(response);
+
     return response.json() as Promise<T>;
 };
 
@@ -121,7 +123,26 @@ export const post = async <T>(url: string, data: unknown): Promise<T> => {
         await handleErrorResponse(response);
     }
 
+    assertNotRedirected(response);
+
     return response.json() as Promise<T>;
+};
+
+/**
+ * Guard against a response that fetch silently followed to a different page.
+ *
+ * The passkey endpoints are guest only, so when the session is already
+ * authenticated the server replies with a redirect to an HTML page. fetch
+ * follows it by default, so `response.ok` is true but the body is HTML and
+ * `response.json()` would throw a cryptic "Unexpected token '<', "<!DOCTYPE ""
+ * error. Surface a clear, actionable message instead.
+ */
+const assertNotRedirected = (response: Response): void => {
+    if (response.redirected) {
+        throw new Error(
+            "The passkey request was redirected instead of returning JSON. You may already be signed in; refresh the page and try again.",
+        );
+    }
 };
 
 /**

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -99,6 +99,18 @@ describe("http", () => {
                 "Request failed with status 500",
             );
         });
+
+        it("throws a clear error when the request was redirected to a non-JSON page", async () => {
+            fetchMock.mockResolvedValue({
+                ok: true,
+                redirected: true,
+                json: () => Promise.resolve({}),
+            });
+
+            await expect(get("/api/test")).rejects.toThrow(
+                "The passkey request was redirected instead of returning JSON. You may already be signed in; refresh the page and try again.",
+            );
+        });
     });
 
     describe("post", () => {
@@ -249,6 +261,18 @@ describe("http", () => {
                 credentials: "same-origin",
                 body: JSON.stringify({}),
             });
+        });
+
+        it("throws a clear error when the request was redirected to a non-JSON page", async () => {
+            fetchMock.mockResolvedValue({
+                ok: true,
+                redirected: true,
+                json: () => Promise.resolve({}),
+            });
+
+            await expect(post("/api/test", {})).rejects.toThrow(
+                "The passkey request was redirected instead of returning JSON. You may already be signed in; refresh the page and try again.",
+            );
         });
     });
 });


### PR DESCRIPTION
## Problem

`get`/`post` in `src/http.ts` only guard `!response.ok` before calling `response.json()`. The passkey routes are guest-only and `fetch` follows redirects by default, so when a request is made while the session is **already authenticated** (for example a back/forward-cached login page, or a second tab), the server's `RedirectIfAuthenticated` returns a `302` to an HTML page. `fetch` follows it, so `response.ok` is `true` (`200`) but the body is HTML, and `response.json()` throws the cryptic:

```
Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

which surfaces to the user as a `PasskeyError` carrying that message instead of anything actionable.

## Fix

Reject a followed redirect (`response.redirected`) on the success path with a clear, actionable message, in both `get` and `post`.

This is intentionally minimal and targeted at the reported scenario (a redirect followed to a non-JSON page). A content-type check could additionally cover a server that returns HTML with a bare `200` and no redirect, but that is a separate edge case and would change the existing mocks; happy to extend if you'd prefer that direction.

## Tests

Adds a `get` and a `post` test for the redirected-response case. `npm run typecheck`, `npm run lint`, `prettier --check`, and the full suite (74 tests) pass.
