### PR TITLE
Add remember-me support

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,10 +3,10 @@ name: dependabot-auto-merge
 on: pull_request
 
 permissions:
-  contents: write
-  pull-requests: write
+    contents: write
+    pull-requests: write
 
 jobs:
-  dependabot:
-    if: ${{ github.actor == 'dependabot[bot]' }}
-    uses: laravel/.github/.github/workflows/dependabot-auto-merge.yml@c265c45c41ccb723befb7a2b807dffff4595bd39
+    dependabot:
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        uses: laravel/.github/.github/workflows/dependabot-auto-merge.yml@c265c45c41ccb723befb7a2b807dffff4595bd39

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ await Passkeys.register({ name: "MacBook Pro" });
 
 // Verify passkey
 await Passkeys.verify();
+
+// Verify and persist the login
+await Passkeys.verify({ remember: true });
 ```
 
 ## Framework Helpers
@@ -178,15 +181,15 @@ If the browser doesn't support autofill (checked via `isAutofillSupported()`) or
 
 ### Public Methods
 
-| Method                        | Description                                       |
-| ----------------------------- | ------------------------------------------------- |
-| `configure(options)`          | Configure the passkeys client                     |
-| `isSupported()`               | Check if the browser supports passkeys            |
-| `isAutofillSupported()`       | Check if the browser supports passkey autofill    |
-| `register({ name, routes? })` | Register a new passkey for the authenticated user |
-| `verify(options?)`            | Verify a passkey                                  |
-| `autofill(options?)`          | Enable passkey autofill on the current page       |
-| `cancel()`                    | Cancel any pending passkey operation              |
+| Method                             | Description                                       |
+| ---------------------------------- | ------------------------------------------------- |
+| `configure(options)`               | Configure the passkeys client                     |
+| `isSupported()`                    | Check if the browser supports passkeys            |
+| `isAutofillSupported()`            | Check if the browser supports passkey autofill    |
+| `register({ name, routes? })`      | Register a new passkey for the authenticated user |
+| `verify({ remember?, routes? })`   | Verify a passkey                                  |
+| `autofill({ remember?, routes? })` | Enable passkey autofill on the current page       |
+| `cancel()`                         | Cancel any pending passkey operation              |
 
 ### Client Configuration
 
@@ -240,7 +243,7 @@ await Passkeys.verify({
 });
 ```
 
-`register()`, `verify()`, and `autofill()` all use:
+`register()`, `verify()`, and `autofill()` all support route overrides:
 
 ```ts
 type RouteOverrides = {
@@ -249,6 +252,50 @@ type RouteOverrides = {
         submit?: string;
     };
 };
+```
+
+### Remember Me
+
+Pass `remember: true` when verifying to keep the user logged in. The flag is
+always sent with the login request and defaults to `false`:
+
+```js
+await Passkeys.verify({ remember: true });
+```
+
+`remember` can also be a function. It is called when the login request is
+sent, after the passkey ceremony completes, so it can read the current state
+of a "Remember me" checkbox. This matters for autofill because the ceremony
+starts on page load before the user picks a credential.
+
+```js
+await Passkeys.autofill({
+    remember: () => document.querySelector("#remember").checked,
+});
+```
+
+The framework adapters accept `remember` too, and apply it to both verify and
+autofill:
+
+```jsx
+// React: a value or a getter
+const [rememberMe, setRememberMe] = useState(false);
+
+usePasskeyVerify({ autofill: true, remember: rememberMe });
+```
+
+```js
+// Vue: a value, a ref, or a getter
+const rememberMe = ref(false);
+
+usePasskeyVerify({ autofill: true, remember: rememberMe });
+```
+
+```js
+// Svelte: pass a getter so $state stays live
+let rememberMe = $state(false);
+
+usePasskeyVerify({ autofill: true, remember: () => rememberMe });
 ```
 
 ### React / Vue / Svelte Route Overrides

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     },
     "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
-        "vue": "^3.0.0",
+        "vue": "^3.3.0",
         "svelte": "^5.0.0"
     },
     "peerDependenciesMeta": {
@@ -89,7 +89,7 @@
         "vite": "^7.0.0",
         "vite-plugin-dts": "^4.5.0",
         "vitest": "^3.0.0",
-        "vue": "^3.0.0",
+        "vue": "^3.3.0",
         "@vue/test-utils": "^2.4.0",
         "@sveltejs/vite-plugin-svelte": "^6.0.0",
         "react": "^18.2.0",

--- a/src/adapters/react.ts
+++ b/src/adapters/react.ts
@@ -7,13 +7,14 @@ import {
 } from "react";
 import { PasskeyError, toPasskeyError } from "../errors";
 import { Passkeys } from "../passkeys";
+import { resolveRemember } from "../remember";
 import type {
     RegisterRouteOptions,
+    VerifyOptions,
     VerifyResponse,
-    VerifyRouteOptions,
 } from "../types";
 
-type UsePasskeyVerifyOptions = VerifyRouteOptions & {
+type UsePasskeyVerifyOptions = VerifyOptions & {
     autofill?: boolean;
     onSuccess?: (response: VerifyResponse) => void;
     onError?: (error: PasskeyError) => void;
@@ -34,6 +35,7 @@ const getSupportServerSnapshot = () => false;
 
 export const usePasskeyVerify = ({
     autofill = false,
+    remember,
     routes,
     onSuccess,
     onError,
@@ -51,11 +53,13 @@ export const usePasskeyVerify = ({
 
     const onSuccessRef = useRef(onSuccess);
     const onErrorRef = useRef(onError);
+    const rememberRef = useRef(remember);
     const routesRef = useRef(routes);
 
     useEffect(() => {
         onSuccessRef.current = onSuccess;
         onErrorRef.current = onError;
+        rememberRef.current = remember;
         routesRef.current = routes;
     });
 
@@ -78,6 +82,7 @@ export const usePasskeyVerify = ({
         try {
             const response = await Passkeys.verify({
                 routes: routesRef.current,
+                remember: () => resolveRemember(rememberRef.current),
             });
             onSuccessRef.current?.(response);
         } catch (e) {
@@ -109,6 +114,7 @@ export const usePasskeyVerify = ({
             try {
                 const response = await Passkeys.autofill({
                     routes: routesRef.current,
+                    remember: () => resolveRemember(rememberRef.current),
                 });
 
                 if (cancelled || !response) {

--- a/src/adapters/svelte.svelte.ts
+++ b/src/adapters/svelte.svelte.ts
@@ -3,11 +3,11 @@ import { PasskeyError, toPasskeyError } from "../errors";
 import { Passkeys } from "../passkeys";
 import type {
     RegisterRouteOptions,
+    VerifyOptions,
     VerifyResponse,
-    VerifyRouteOptions,
 } from "../types";
 
-type UsePasskeyVerifyOptions = VerifyRouteOptions & {
+type UsePasskeyVerifyOptions = VerifyOptions & {
     autofill?: boolean;
     onSuccess?: (response: VerifyResponse) => void;
     onError?: (error: PasskeyError) => void;
@@ -20,6 +20,7 @@ type UsePasskeyRegisterOptions = RegisterRouteOptions & {
 
 export function usePasskeyVerify({
     autofill = false,
+    remember,
     routes,
     onSuccess,
     onError,
@@ -42,12 +43,12 @@ export function usePasskeyVerify({
         onError?.(err);
     };
 
-    const verify = async () => {
+    const verify = async (): Promise<void> => {
         isLoading = true;
         resetError();
 
         try {
-            const response = await Passkeys.verify({ routes });
+            const response = await Passkeys.verify({ routes, remember });
             onSuccess?.(response);
         } catch (e) {
             handleError(e);
@@ -76,9 +77,7 @@ export function usePasskeyVerify({
             resetError();
 
             try {
-                const response = await Passkeys.autofill({
-                    routes,
-                });
+                const response = await Passkeys.autofill({ routes, remember });
 
                 if (response) {
                     onSuccess?.(response);

--- a/src/adapters/vue.ts
+++ b/src/adapters/vue.ts
@@ -1,4 +1,5 @@
-import { onMounted, onUnmounted, ref } from "vue";
+import { onMounted, onUnmounted, ref, toValue } from "vue";
+import type { MaybeRefOrGetter } from "vue";
 import { PasskeyError, toPasskeyError } from "../errors";
 import { Passkeys } from "../passkeys";
 import type {
@@ -9,6 +10,7 @@ import type {
 
 type UsePasskeyVerifyOptions = VerifyRouteOptions & {
     autofill?: boolean;
+    remember?: MaybeRefOrGetter<boolean>;
     onSuccess?: (response: VerifyResponse) => void;
     onError?: (error: PasskeyError) => void;
 };
@@ -20,6 +22,7 @@ type UsePasskeyRegisterOptions = RegisterRouteOptions & {
 
 export const usePasskeyVerify = ({
     autofill = false,
+    remember,
     routes,
     onSuccess,
     onError,
@@ -42,12 +45,15 @@ export const usePasskeyVerify = ({
         onError?.(err);
     };
 
-    const verify = async () => {
+    const verify = async (): Promise<void> => {
         isLoading.value = true;
         resetError();
 
         try {
-            const response = await Passkeys.verify({ routes });
+            const response = await Passkeys.verify({
+                routes,
+                remember: () => toValue(remember) ?? false,
+            });
             onSuccess?.(response);
         } catch (e) {
             handleError(e);
@@ -79,6 +85,7 @@ export const usePasskeyVerify = ({
         try {
             const response = await Passkeys.autofill({
                 routes,
+                remember: () => toValue(remember) ?? false,
             });
 
             if (response) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,10 +14,12 @@ export type { PasskeyRoutes } from "./routes";
 export type {
     PasskeysConfig,
     PasskeysFetchConfig,
+    RememberOption,
     RouteOverrides,
     RegisterOptions,
     RegisterRouteOptions,
     RegistrationResponse,
+    VerifyOptions,
     VerifyRouteOptions,
     VerifyResponse,
 } from "./types";

--- a/src/passkeys.ts
+++ b/src/passkeys.ts
@@ -7,6 +7,7 @@ import {
 } from "@simplewebauthn/browser";
 import { NotSupportedError, toPasskeyError } from "./errors";
 import { configure as configureHttp, get, post } from "./http";
+import { resolveRemember } from "./remember";
 import { defaultRoutes } from "./routes";
 import type {
     PasskeysConfig,
@@ -15,10 +16,10 @@ import type {
     RegistrationRequest,
     RegistrationResponse,
     RouteOverrides,
+    VerifyOptions,
     VerifyOptionsResponse,
     VerifyRequest,
     VerifyResponse,
-    VerifyRouteOptions,
 } from "./types";
 
 /**
@@ -85,7 +86,7 @@ export const Passkeys = {
     /**
      * Verify with a passkey.
      */
-    async verify(options: VerifyRouteOptions = {}): Promise<VerifyResponse> {
+    async verify(options: VerifyOptions = {}): Promise<VerifyResponse> {
         if (!this.isSupported()) {
             throw new NotSupportedError();
         }
@@ -105,7 +106,10 @@ export const Passkeys = {
 
             const credential = await startAuthentication({ optionsJSON });
 
-            const request: VerifyRequest = { credential };
+            const request: VerifyRequest = {
+                credential,
+                remember: resolveRemember(options.remember),
+            };
 
             return await post<VerifyResponse>(routes.submitRoute, request);
         } catch (error) {
@@ -123,7 +127,7 @@ export const Passkeys = {
      * is not supported or was cancelled.
      */
     async autofill(
-        options: VerifyRouteOptions = {},
+        options: VerifyOptions = {},
     ): Promise<VerifyResponse | undefined> {
         if (!this.isSupported()) {
             return;
@@ -150,7 +154,10 @@ export const Passkeys = {
                 useBrowserAutofill: true,
             });
 
-            const request: VerifyRequest = { credential };
+            const request: VerifyRequest = {
+                credential,
+                remember: resolveRemember(options.remember),
+            };
 
             return await post<VerifyResponse>(routes.submitRoute, request);
         } catch (error) {

--- a/src/remember.ts
+++ b/src/remember.ts
@@ -1,0 +1,8 @@
+import type { RememberOption } from "./types";
+
+/**
+ * Resolve a remember option to its boolean value at submit time, so getters
+ * report live UI state.
+ */
+export const resolveRemember = (remember?: RememberOption): boolean =>
+    (typeof remember === "function" ? remember() : remember) ?? false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,15 @@ export type RegisterRouteOptions = RouteOverrides;
 
 export type VerifyRouteOptions = RouteOverrides;
 
+/**
+ * Whether the authenticated user should be remembered.
+ */
+export type RememberOption = boolean | (() => boolean);
+
+export type VerifyOptions = VerifyRouteOptions & {
+    remember?: RememberOption;
+};
+
 export type RegisterOptions = {
     /**
      * Human-readable name for this passkey (e.g., "MacBook Pro", "Work Laptop").
@@ -76,6 +85,7 @@ export type RegistrationRequest = {
  */
 export type VerifyRequest = {
     credential: AuthenticationResponseJSON;
+    remember: boolean;
 };
 
 /**

--- a/tests/adapters/TestVerify.svelte
+++ b/tests/adapters/TestVerify.svelte
@@ -4,6 +4,7 @@
     interface Props {
         autofill?: boolean;
         routes: { options: string; submit: string };
+        remember?: boolean | (() => boolean);
         onSuccess?: (response: { redirect?: string }) => void;
         onError?: (error: Error) => void;
     }

--- a/tests/adapters/react.test.tsx
+++ b/tests/adapters/react.test.tsx
@@ -51,9 +51,9 @@ describe("React adapter", () => {
             (Passkeys.isSupported as Mock).mockReturnValue(true);
 
             function Probe() {
-                const { isSupported } = usePasskeyVerify({ routes });
+                const { isSupported, verify } = usePasskeyVerify({ routes });
 
-                return <span>{String(isSupported)}</span>;
+                return <button onClick={verify}>{String(isSupported)}</button>;
             }
 
             const html = renderToString(<Probe />);
@@ -79,9 +79,33 @@ describe("React adapter", () => {
                 expect(result.current.isLoading).toBe(false);
             });
 
-            expect(Passkeys.verify).toHaveBeenCalledWith({ routes });
+            expect(Passkeys.verify).toHaveBeenCalledWith({
+                routes,
+                remember: expect.any(Function),
+            });
             expect(result.current.error).toBeNull();
             expect(onSuccess).toHaveBeenCalledWith(response);
+        });
+
+        it("resolves remember from the latest render when verifying", async () => {
+            (Passkeys.verify as Mock).mockResolvedValue({});
+
+            const { result, rerender } = renderHook(
+                ({ remember }: { remember: boolean }) =>
+                    usePasskeyVerify({ routes, remember }),
+                { initialProps: { remember: false } },
+            );
+
+            rerender({ remember: true });
+
+            await act(async () => {
+                await result.current.verify();
+            });
+
+            const options = (Passkeys.verify as Mock).mock.calls[0][0] as {
+                remember: () => boolean;
+            };
+            expect(options.remember()).toBe(true);
         });
 
         it("sets error and calls onError when verify rejects", async () => {
@@ -154,7 +178,32 @@ describe("React adapter", () => {
                 expect(onSuccess).toHaveBeenCalledWith(response);
             });
 
-            expect(Passkeys.autofill).toHaveBeenCalledWith({ routes });
+            expect(Passkeys.autofill).toHaveBeenCalledWith({
+                routes,
+                remember: expect.any(Function),
+            });
+        });
+
+        it("forwards configured remember to autofill", async () => {
+            (Passkeys.isAutofillSupported as Mock).mockResolvedValue(true);
+            (Passkeys.autofill as Mock).mockResolvedValue({});
+
+            renderHook(() =>
+                usePasskeyVerify({
+                    routes,
+                    remember: true,
+                    autofill: true,
+                }),
+            );
+
+            await waitFor(() => {
+                expect(Passkeys.autofill).toHaveBeenCalled();
+            });
+
+            const options = (Passkeys.autofill as Mock).mock.calls[0][0] as {
+                remember: () => boolean;
+            };
+            expect(options.remember()).toBe(true);
         });
 
         it("skips post-unmount callbacks when autofill resolves after unmount", async () => {

--- a/tests/adapters/svelte.test.ts
+++ b/tests/adapters/svelte.test.ts
@@ -63,11 +63,47 @@ describe("Svelte adapter", () => {
 
             await fireEvent.click(getByRole("button", { name: "Verify" }));
             await waitFor(() => {
-                expect(Passkeys.verify).toHaveBeenCalledWith({ routes });
+                expect(Passkeys.verify).toHaveBeenCalledWith({
+                    routes,
+                    remember: undefined,
+                });
             });
 
             expect(getByTestId("error").textContent).toBe("");
             expect(onSuccess).toHaveBeenCalledWith(response);
+        });
+
+        it("forwards remember to Passkeys.verify", async () => {
+            (Passkeys.verify as Mock).mockResolvedValue({});
+
+            const { getByRole } = render(TestVerify, {
+                props: { routes, remember: true },
+            });
+
+            await fireEvent.click(getByRole("button", { name: "Verify" }));
+            await waitFor(() => {
+                expect(Passkeys.verify).toHaveBeenCalledWith({
+                    routes,
+                    remember: true,
+                });
+            });
+        });
+
+        it("passes remember getters through to Passkeys.verify", async () => {
+            (Passkeys.verify as Mock).mockResolvedValue({});
+
+            const remember = () => true;
+            const { getByRole } = render(TestVerify, {
+                props: { routes, remember },
+            });
+
+            await fireEvent.click(getByRole("button", { name: "Verify" }));
+            await waitFor(() => {
+                expect(Passkeys.verify).toHaveBeenCalledWith({
+                    routes,
+                    remember,
+                });
+            });
         });
 
         it("sets error and calls onError when verify rejects", async () => {
@@ -136,7 +172,26 @@ describe("Svelte adapter", () => {
                 expect(onSuccess).toHaveBeenCalledWith(response);
             });
 
-            expect(Passkeys.autofill).toHaveBeenCalledWith({ routes });
+            expect(Passkeys.autofill).toHaveBeenCalledWith({
+                routes,
+                remember: undefined,
+            });
+        });
+
+        it("forwards configured remember to autofill", async () => {
+            (Passkeys.isAutofillSupported as Mock).mockResolvedValue(true);
+            (Passkeys.autofill as Mock).mockResolvedValue({});
+
+            render(TestVerify, {
+                props: { routes, remember: true, autofill: true },
+            });
+
+            await waitFor(() => {
+                expect(Passkeys.autofill).toHaveBeenCalledWith({
+                    routes,
+                    remember: true,
+                });
+            });
         });
 
         it("calls Passkeys.cancel on unmount", async () => {

--- a/tests/adapters/vue.test.ts
+++ b/tests/adapters/vue.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
-import { defineComponent, h, createSSRApp } from "vue";
+import { defineComponent, h, createSSRApp, ref } from "vue";
+import type { MaybeRefOrGetter } from "vue";
 import { renderToString } from "@vue/server-renderer";
 import { Passkeys } from "../../src/passkeys";
 import { PasskeyError, PasskeyExistsError } from "../../src/errors";
@@ -19,7 +20,10 @@ vi.mock("../../src/passkeys", () => ({
 
 const routes = { options: "/opts", submit: "/submit" };
 
-const createVerifyWrapper = (autofill = false) =>
+const createVerifyWrapper = (
+    autofill = false,
+    remember?: MaybeRefOrGetter<boolean>,
+) =>
     defineComponent({
         setup() {
             const onSuccess = vi.fn();
@@ -29,6 +33,7 @@ const createVerifyWrapper = (autofill = false) =>
                 onSuccess,
                 onError,
                 autofill,
+                remember,
             });
             return { passkey, onSuccess, onError };
         },
@@ -136,9 +141,29 @@ describe("Vue adapter", () => {
             await wrapper.find("[data-verify]").trigger("click");
             await flushPromises();
 
-            expect(Passkeys.verify).toHaveBeenCalledWith({ routes });
+            expect(Passkeys.verify).toHaveBeenCalledWith({
+                routes,
+                remember: expect.any(Function),
+            });
             expect(wrapper.find("[data-error]").text()).toBe("");
             expect(vm.onSuccess).toHaveBeenCalledWith(response);
+        });
+
+        it("resolves remember from a ref when verifying", async () => {
+            (Passkeys.verify as Mock).mockResolvedValue({});
+
+            const rememberMe = ref(false);
+            const wrapper = mount(createVerifyWrapper(false, rememberMe));
+            await flushPromises();
+
+            rememberMe.value = true;
+            await wrapper.find("[data-verify]").trigger("click");
+            await flushPromises();
+
+            const options = (Passkeys.verify as Mock).mock.calls[0][0] as {
+                remember: () => boolean;
+            };
+            expect(options.remember()).toBe(true);
         });
 
         it("sets error and calls onError when verify rejects", async () => {
@@ -206,7 +231,23 @@ describe("Vue adapter", () => {
                 onSuccess: ReturnType<typeof vi.fn>;
             };
             expect(vm.onSuccess).toHaveBeenCalledWith(response);
-            expect(Passkeys.autofill).toHaveBeenCalledWith({ routes });
+            expect(Passkeys.autofill).toHaveBeenCalledWith({
+                routes,
+                remember: expect.any(Function),
+            });
+        });
+
+        it("forwards configured remember to autofill", async () => {
+            (Passkeys.isAutofillSupported as Mock).mockResolvedValue(true);
+            (Passkeys.autofill as Mock).mockResolvedValue({});
+
+            mount(createVerifyWrapper(true, () => true));
+            await flushPromises();
+
+            const options = (Passkeys.autofill as Mock).mock.calls[0][0] as {
+                remember: () => boolean;
+            };
+            expect(options.remember()).toBe(true);
         });
 
         it("calls Passkeys.cancel on unmount", async () => {

--- a/tests/passkeys.test.ts
+++ b/tests/passkeys.test.ts
@@ -288,6 +288,92 @@ describe("Passkeys", () => {
             expect(result).toEqual(mockVerifyResponse);
         });
 
+        it("includes remember when explicitly provided", async () => {
+            const mockResponse = { redirect: "/dashboard" };
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: () => Promise.resolve(mockOptionsResponse),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: () => Promise.resolve(mockResponse),
+                });
+            (startAuthentication as Mock).mockResolvedValue(mockCredential);
+
+            await Passkeys.verify({ remember: true });
+
+            expect(fetchMock).toHaveBeenNthCalledWith(
+                2,
+                "/passkeys/login",
+                expect.objectContaining({
+                    body: JSON.stringify({
+                        credential: mockCredential,
+                        remember: true,
+                    }),
+                }),
+            );
+        });
+
+        it("sends remember as false when it is not provided", async () => {
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: () => Promise.resolve(mockOptionsResponse),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: () => Promise.resolve(mockVerifyResponse),
+                });
+            (startAuthentication as Mock).mockResolvedValue(mockCredential);
+
+            await Passkeys.verify();
+
+            expect(fetchMock).toHaveBeenNthCalledWith(
+                2,
+                "/passkeys/login",
+                expect.objectContaining({
+                    body: JSON.stringify({
+                        credential: mockCredential,
+                        remember: false,
+                    }),
+                }),
+            );
+        });
+
+        it("resolves remember getters when the login request is sent", async () => {
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: () => Promise.resolve(mockOptionsResponse),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: () => Promise.resolve(mockVerifyResponse),
+                });
+
+            // Flip the value during the ceremony to prove the getter is read
+            // at submit time rather than when verify() was called.
+            let remembered = false;
+            (startAuthentication as Mock).mockImplementation(async () => {
+                remembered = true;
+                return mockCredential;
+            });
+
+            await Passkeys.verify({ remember: () => remembered });
+
+            expect(fetchMock).toHaveBeenNthCalledWith(
+                2,
+                "/passkeys/login",
+                expect.objectContaining({
+                    body: JSON.stringify({
+                        credential: mockCredential,
+                        remember: true,
+                    }),
+                }),
+            );
+        });
+
         it("allows explicit route overrides per verify call", async () => {
             fetchMock
                 .mockResolvedValueOnce({
@@ -434,6 +520,33 @@ describe("Passkeys", () => {
                 useBrowserAutofill: true,
             });
             expect(result).toEqual(mockResponse);
+        });
+
+        it("includes remember in the autofill request when explicitly provided", async () => {
+            const mockResponse = { redirect: "/dashboard" };
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: () => Promise.resolve(mockOptionsResponse),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: () => Promise.resolve(mockResponse),
+                });
+            (startAuthentication as Mock).mockResolvedValue(mockCredential);
+
+            await Passkeys.autofill({ remember: true });
+
+            expect(fetchMock).toHaveBeenNthCalledWith(
+                2,
+                "/passkeys/login",
+                expect.objectContaining({
+                    body: JSON.stringify({
+                        credential: mockCredential,
+                        remember: true,
+                    }),
+                }),
+            );
         });
 
         it("allows explicit route overrides per autofill call", async () => {


### PR DESCRIPTION
Fixes #28.

Adds a remember option to `Passkeys.verify()` and `Passkeys.autofill()` bringing this package inline with [passkeys-server](https://github.com/laravel/passkeys-server) which is already setup to accept the field.

The option takes a boolean or a function. Functions are useful here because they are called when the login request is sent. This matters because the user could modify the "Remember me" checkbox after the ceremony starts and before they submit the credential.